### PR TITLE
Add the event handler in tests using `dom-events`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "6to5": "^2.5.0",
     "detect-node": "^2.0.3",
+    "dom-events": "^0.1.1",
     "esperanto": "^0.5.7",
     "function-bind": "^1.0.2",
     "gobble": "^0.7.1",

--- a/test/keysim_test.js
+++ b/test/keysim_test.js
@@ -6,6 +6,7 @@ if (!Function.prototype.bind) {
 var assert = require('assert');
 var Keyboard = require('../dist/keysim').Keyboard;
 var Keystroke = require('../dist/keysim').Keystroke;
+var on = require('dom-events').on;
 
 var isInNode = require('detect-node');
 
@@ -20,7 +21,7 @@ function captureEvents(element, body) {
     }
   };
   ['keydown', 'keypress', 'keyup', 'textInput'].forEach(function(type) {
-    element.addEventListener(type, handler);
+    on(element, type, handler);
   });
   body();
   return events;


### PR DESCRIPTION
IE (perhaps before 11) doesn't have `Element.prototype.addEventListener`. It has `Element.prototype.attachEvent`, instead.

This module handles this difference.