### PR TITLE
Add the event handler in tests using add-event-handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "karma-mocha": "^0.1.10",
     "karma-sauce-launcher": "^0.2.10",
     "mocha": "^2.1.0"
+  },
+  "dependencies": {
+    "add-event-handler": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "6to5": "^2.5.0",
+    "add-event-handler": "^1.0.0",
     "detect-node": "^2.0.3",
     "es5-shim": "^4.0.5",
     "esperanto": "^0.5.7",
@@ -43,8 +44,5 @@
     "karma-mocha": "^0.1.10",
     "karma-sauce-launcher": "^0.2.10",
     "mocha": "^2.1.0"
-  },
-  "dependencies": {
-    "add-event-handler": "^1.0.0"
   }
 }

--- a/test/keysim_test.js
+++ b/test/keysim_test.js
@@ -8,6 +8,7 @@ var isInNode = require('detect-node');
 
 // jsdom is required when running in node. Browsers have real DOM.
 var jsdom = isInNode ? require('jsdom') : null;
+var addEventHandler = require('add-event-handler');
 
 function captureEvents(element, body) {
   var events = [];
@@ -17,7 +18,7 @@ function captureEvents(element, body) {
     }
   };
   ['keydown', 'keypress', 'keyup', 'textInput'].forEach(function(type) {
-    element.addEventListener(type, handler);
+      addEventHandler(element, type, handler);
   });
   body();
   return events;


### PR DESCRIPTION
Replaces #14.

#14 couldn't work in node because `dom-events` has a dep on `synthetic-dom-events`, which expects the browser–only global `window`.

`dom-events`' use of `synthetic-dom-events` is not at all for adding event handlers, but for its `.emit` method, which we're not using.

So, one could say that `dom-events` is not tightly scoped enough for us.

I've created [`add-event-handler`](https://github.com/mightyiam/add-event-handler) which is tightly scoped around choosing between `Element.prototype.addEventListener` and `Element.prototype.attachEvent`.

Since it checks on the provided element (`if (element.addEventListener) {...}`) it doesn't expect a global `window`, `Element` or anything that one would require a browser for. Thus it works in node with elements that provide one of those methods (we're talking about `addEventListener` in jsdom).

It is similar to `dom-event`'s `.on` but, again, it does not check on `document`, like `dom-event` does, so it doesn't fail in node.