### PR TITLE
createEventFromKeystroke: use get-window and get-document modules

### DIFF
--- a/lib/keysim.js
+++ b/lib/keysim.js
@@ -96,8 +96,10 @@ export class Keyboard {
    * @return {Event}
    */
   createEventFromKeystroke(type, keystroke, target) {
-    var document = target.ownerDocument;
-    var window = document.defaultView;
+    var getWindow = require('get-window');
+    var getDocument = require('get-document');
+    var window = getWindow(target);
+    var document = getDocument(target);
     var Event = window.Event;
 
     var event;

--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     "karma-mocha": "^0.1.10",
     "karma-sauce-launcher": "^0.2.10",
     "mocha": "^2.1.0"
+  },
+  "dependencies": {
+    "get-document": "^0.1.1",
+    "get-window": "0.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "get-document": "^0.1.1",
-    "get-window": "git://github.com/mightyiam/get-window#parentWindow"
+    "get-document": "^1.0.0",
+    "get-window": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "get-document": "^0.1.1",
-    "get-window": "0.0.2"
+    "get-window": "git://github.com/mightyiam/get-window#parentWindow"
   }
 }


### PR DESCRIPTION
Apparently, getting the window and the document varies across browsers. This is cross browser and works in jsdom.