### PR TITLE
Added keypress event outside of text input

### DIFF
--- a/lib/keysim.js
+++ b/lib/keysim.js
@@ -203,6 +203,9 @@ export class Keyboard {
         const textinputEvent = this.createEventFromKeystroke('textInput', keystroke, target);
         target.dispatchEvent(textinputEvent);
       }
+    } else {
+      const keypressEvent = this.createEventFromKeystroke('keypress', keystroke, target);
+      target.dispatchEvent(keypressEvent);
     }
 
     const keyupEvent = this.createEventFromKeystroke('keyup', keystroke, target);


### PR DESCRIPTION
A keypress still is invoked out of the input. Using mousetrap.js, it cannot invoke its events without the keypress from occurring. Tested on Mac in Chrome. If you would like to see that the "keypress" event does invoke...

document.addEventListener('keypress', function(){
  console.log('keypress');
}, true)

This fires whether in or out of a text input.