### PR TITLE
Keyboard Events are not created correctly.

### DIFF
--- a/test/keysim_test.js
+++ b/test/keysim_test.js
@@ -358,6 +358,12 @@ describe('Keyboard', function() {
         ['keyup', 0, 67]
       ]);
     });
+
+    it('causes the input to update the value based on the dispatched events', function() {
+      var keyboard = Keyboard.US_ENGLISH;
+      keyboard.dispatchEventsForInput('ABc', input);
+      assert.strictEqual(input.value, 'ABc');
+    })
   });
 
   describe('#dispatchEventsForAction', function() {


### PR DESCRIPTION
I have a failing test to show that this library doesn't actually work because the keyboard events are not created correctly. I'm quite sure [simkey](https://github.com/DamonOehlman/simkey) is doing it correctly by [creating a `KeyboardEvent`](https://github.com/DamonOehlman/simkey/blob/6aabe6830d11310761268be9dc7f3195f37c0792/index.js#L20-L34). I'll update this PR with the fix, but wanted to show the failing test (hopefully, I know SauceLabs doesn't run during a PR.)