### PR TITLE
chore: move mocha options into mocha.opts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "gobble build dist -f",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "./node_modules/karma/bin/karma start karma.conf.js",
-    "test:node": "mocha -R spec --recursive test"
+    "test:node": "mocha"
   },
   "files": [
     "dist/keysim.js",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--recursive


### PR DESCRIPTION
This makes it easier for IDEs etc to integrate with mocha.