### PR TITLE
chore: fix sauce labs tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -79,6 +79,9 @@ module.exports = function(config) {
     // enable / disable colors in the output (reporters and logs)
     colors: true,
 
+    // Only launch 1 at a time to get around resource limits.
+    concurrency: useSauceLabs ? 1 : undefined,
+
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG

--- a/package.json
+++ b/package.json
@@ -31,20 +31,22 @@
   "author": "Brian Donovan",
   "license": "MIT",
   "devDependencies": {
-    "add-event-handler": "^1.0.0",
+    "add-event-handler": "^1.0.3",
     "babel": "^5.8.21",
+    "browserify": "^13.0.1",
     "detect-node": "^2.0.3",
-    "es5-shim": "^4.1.10",
+    "es5-shim": "^4.5.9",
     "esperanto": "^0.7.4",
     "gobble": "^0.10.2",
     "gobble-cli": "^0.4.2",
-    "jsdom": "3.1.2",
-    "karma": "^0.13.9",
-    "karma-browserify": "^4.3.0",
-    "karma-chrome-launcher": "^0.2.0",
-    "karma-firefox-launcher": "^0.1.6",
-    "karma-mocha": "^0.2.0",
-    "karma-sauce-launcher": "^0.2.14",
-    "mocha": "^2.2.5"
+    "jsdom": "^3.1.2",
+    "karma": "^1.1.1",
+    "karma-browserify": "^5.0.5",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-mocha": "^1.1.1",
+    "karma-sauce-launcher": "^1.0.0",
+    "mocha": "^2.5.3",
+    "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
Per https://github.com/karma-runner/karma-sauce-launcher/issues/40, it seems that we can only run 1 browser at a time in sauce labs. This updates karma to a version that supports the `concurrency` option.