### PR TITLE
Support HTML5 input event

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let keyboard = Keysim.Keyboard.US_ENGLISH;
 keyboard.dispatchEventsForInput('hello!', input);
 ```
 
-This will fire events `keydown`, `keypress`, `keyup`, and `textInput` events
+This will fire events `keydown`, `keypress`, `keyup`, `textInput` and `input` events
 for each typed character in the input string. In addition, some characters
 may require modifier keys in order to type. The `keydown` and `keyup` events
 will be fired for these modifier keys (e.g. the SHIFT key) as appropriate.
@@ -78,27 +78,33 @@ keyboard.dispatchEventsForKeystroke(ctrl_shift_enter, input);
 keydown  keyCode=72  (H)   which=72  (H)   charCode=0        
 keypress keyCode=104 (h)   which=104 (h)   charCode=104 (h)  
 textInput data=h
+input data=h
 keyup    keyCode=72  (H)   which=72  (H)   charCode=0        
 keydown  keyCode=69  (E)   which=69  (E)   charCode=0        
 keypress keyCode=101 (e)   which=101 (e)   charCode=101 (e)  
 textInput data=e
+input data=e
 keyup    keyCode=69  (E)   which=69  (E)   charCode=0        
 keydown  keyCode=76  (L)   which=76  (L)   charCode=0        
 keypress keyCode=108 (l)   which=108 (l)   charCode=108 (l)  
 textInput data=l
+input data=l
 keyup    keyCode=76  (L)   which=76  (L)   charCode=0        
 keydown  keyCode=76  (L)   which=76  (L)   charCode=0        
 keypress keyCode=108 (l)   which=108 (l)   charCode=108 (l)  
 textInput data=l
+input data=l
 keyup    keyCode=76  (L)   which=76  (L)   charCode=0        
 keydown  keyCode=79  (O)   which=79  (O)   charCode=0        
 keypress keyCode=111 (o)   which=111 (o)   charCode=111 (o)  
 textInput data=o
+input data=o
 keyup    keyCode=79  (O)   which=79  (O)   charCode=0        
 keydown  keyCode=16        which=16        charCode=0        
 keydown  keyCode=49  (1)   which=49  (1)   charCode=0        
 keypress keyCode=33  (!)   which=33  (!)   charCode=33  (!)  
 textInput data=!
+input data=!
 keyup    keyCode=49  (1)   which=49  (1)   charCode=0        
 keyup    keyCode=16        which=16        charCode=0        
 keydown  keyCode=91  ([)   which=91  ([)   charCode=0        

--- a/README.md
+++ b/README.md
@@ -78,33 +78,33 @@ keyboard.dispatchEventsForKeystroke(ctrl_shift_enter, input);
 keydown  keyCode=72  (H)   which=72  (H)   charCode=0        
 keypress keyCode=104 (h)   which=104 (h)   charCode=104 (h)  
 textInput data=h
-input data=h
+input
 keyup    keyCode=72  (H)   which=72  (H)   charCode=0        
 keydown  keyCode=69  (E)   which=69  (E)   charCode=0        
 keypress keyCode=101 (e)   which=101 (e)   charCode=101 (e)  
 textInput data=e
-input data=e
+input
 keyup    keyCode=69  (E)   which=69  (E)   charCode=0        
 keydown  keyCode=76  (L)   which=76  (L)   charCode=0        
 keypress keyCode=108 (l)   which=108 (l)   charCode=108 (l)  
 textInput data=l
-input data=l
+input
 keyup    keyCode=76  (L)   which=76  (L)   charCode=0        
 keydown  keyCode=76  (L)   which=76  (L)   charCode=0        
 keypress keyCode=108 (l)   which=108 (l)   charCode=108 (l)  
 textInput data=l
-input data=l
+input
 keyup    keyCode=76  (L)   which=76  (L)   charCode=0        
 keydown  keyCode=79  (O)   which=79  (O)   charCode=0        
 keypress keyCode=111 (o)   which=111 (o)   charCode=111 (o)  
 textInput data=o
-input data=o
+input
 keyup    keyCode=79  (O)   which=79  (O)   charCode=0        
 keydown  keyCode=16        which=16        charCode=0        
 keydown  keyCode=49  (1)   which=49  (1)   charCode=0        
 keypress keyCode=33  (!)   which=33  (!)   charCode=33  (!)  
 textInput data=!
-input data=!
+input
 keyup    keyCode=49  (1)   which=49  (1)   charCode=0        
 keyup    keyCode=16        which=16        charCode=0        
 keydown  keyCode=91  ([)   which=91  ([)   charCode=0        

--- a/src/keysim.js
+++ b/src/keysim.js
@@ -121,7 +121,6 @@ export class Keyboard {
 
     switch (type) {
       case 'textInput':
-      case 'input':
         event.data = String.fromCharCode(this.charCodeForKeystroke(keystroke));
         break;
 
@@ -179,7 +178,7 @@ export class Keyboard {
    *   keydown   keyCode=65 (A)     charCode=0      shiftKey=true
    *   keypress  keyCode=65 (A)     charCode=65 (A) shiftKey=true
    *   textInput data=A
-   *   input data=A
+   *   input
    *   keyup     keyCode=65 (A)     charCode=0      shiftKey=true
    *   keyup     keyCode=16 (SHIFT) charCode=0      shiftKey=false
    *

--- a/src/keysim.js
+++ b/src/keysim.js
@@ -99,7 +99,7 @@ export class Keyboard {
   /**
    * Creates an event ready for dispatching onto the given target.
    *
-   * @param {string} type One of "keydown", "keypress", "keyup", or "textInput".
+   * @param {string} type One of "keydown", "keypress", "keyup", "textInput" or "input".
    * @param {Keystroke} keystroke
    * @param {HTMLElement} target
    * @return {Event}
@@ -121,6 +121,7 @@ export class Keyboard {
 
     switch (type) {
       case 'textInput':
+      case 'input':
         event.data = String.fromCharCode(this.charCodeForKeystroke(keystroke));
         break;
 
@@ -178,6 +179,7 @@ export class Keyboard {
    *   keydown   keyCode=65 (A)     charCode=0      shiftKey=true
    *   keypress  keyCode=65 (A)     charCode=65 (A) shiftKey=true
    *   textInput data=A
+   *   input data=A
    *   keyup     keyCode=65 (A)     charCode=0      shiftKey=true
    *   keyup     keyCode=16 (SHIFT) charCode=0      shiftKey=false
    *
@@ -219,6 +221,14 @@ export class Keyboard {
         if (events & KeyEvents.INPUT) {
           const textinputEvent = this.createEventFromKeystroke('textInput', keystroke, target);
           target.dispatchEvent(textinputEvent);
+          const inputEvent = this.createEventFromKeystroke('input', keystroke, target);
+          target.dispatchEvent(inputEvent);
+        }
+      }
+      if (keystroke.keyCode === US_ENGLISH_ACTION_KEYCODE_MAP.BACKSPACE) {
+        if (events & KeyEvents.INPUT) {
+          const inputEvent = this.createEventFromKeystroke('input', keystroke, target);
+          target.dispatchEvent(inputEvent);
         }
       }
     }

--- a/test/keysim_test.js
+++ b/test/keysim_test.js
@@ -18,7 +18,7 @@ function captureEvents(element, body) {
       events.push(e);
     }
   };
-  ['keydown', 'keypress', 'keyup', 'textInput'].forEach(function(type) {
+  ['keydown', 'keypress', 'keyup', 'textInput', 'input'].forEach(function(type) {
     addEventHandler(element, type, handler);
   });
   body();
@@ -181,7 +181,7 @@ describe('Keyboard', function() {
           input = document.createElement('input');
         });
 
-        it('dispatches keydown, keypress, textInput, and keyup', function() {
+        it('dispatches keydown, keypress, textInput, input, and keyup', function() {
           // Simulate typing 'a'.
           assert.deepEqual(captureEventSummaries(input, function() {
             var keyboard = new Keyboard({ 97: a }, {});
@@ -190,6 +190,7 @@ describe('Keyboard', function() {
             ['keydown', 0, 97],
             ['keypress', 97, 97],
             ['textInput', undefined, undefined],
+            ['input', undefined, undefined],
             ['keyup', 0, 97]
           ]);
         });
@@ -222,6 +223,20 @@ describe('Keyboard', function() {
             ['keydown', 0, 16],
             ['keyup', 0, 16]
           ]);
+        });
+
+        context('when the keystroke will delete a character', function() {
+          it('dispatches keydown, input and keyup', function() {
+            // Simulate pressing the BACKSPACE key itself.
+            assert.deepEqual(captureEventSummaries(input, function() {
+              var keyboard = new Keyboard({}, { BACKSPACE: 8 });
+              keyboard.dispatchEventsForKeystroke(new Keystroke(0, 8), input);
+            }), [
+              ['keydown', 0, 8],
+              ['input', undefined, undefined],
+              ['keyup', 0, 8]
+            ]);
+          });
         });
       });
 
@@ -271,7 +286,7 @@ describe('Keyboard', function() {
       });
 
       context('when the keystroke will input a character', function() {
-        it('dispatches keydown, keypress, textInput, and keyup', function() {
+        it('dispatches keydown, keypress, textInput, input, and keyup', function() {
           // Simulate typing 'A'.
           assert.deepEqual(captureEventSummaries(input, function() {
             var keyboard = new Keyboard({ 65: A }, { SHIFT: 16 });
@@ -284,6 +299,7 @@ describe('Keyboard', function() {
             ['keydown', 0, 97],
             ['keypress', 65, 65],
             ['textInput', undefined, undefined],
+            ['input', undefined, undefined],
             ['keyup', 0, 97],
 
             // shift key
@@ -312,18 +328,21 @@ describe('Keyboard', function() {
         ['keydown', 0, 65],
         ['keypress', 97, 97],
         ['textInput', undefined, undefined],
+        ['input', undefined, undefined],
         ['keyup', 0, 65],
 
         // b
         ['keydown', 0, 66],
         ['keypress', 98, 98],
         ['textInput', undefined, undefined],
+        ['input', undefined, undefined],
         ['keyup', 0, 66],
 
         // c
         ['keydown', 0, 67],
         ['keypress', 99, 99],
         ['textInput', undefined, undefined],
+        ['input', undefined, undefined],
         ['keyup', 0, 67]
       ]);
     });
@@ -340,12 +359,14 @@ describe('Keyboard', function() {
         ['keydown', 0, 65],
         ['keypress', 65, 65],
         ['textInput', undefined, undefined],
+        ['input', undefined, undefined],
         ['keyup', 0, 65],
 
         // B
         ['keydown', 0, 66],
         ['keypress', 66, 66],
         ['textInput', undefined, undefined],
+        ['input', undefined, undefined],
         ['keyup', 0, 66],
 
         // shift
@@ -355,6 +376,7 @@ describe('Keyboard', function() {
         ['keydown', 0, 67],
         ['keypress', 99, 99],
         ['textInput', undefined, undefined],
+        ['input', undefined, undefined],
         ['keyup', 0, 67]
       ]);
     });
@@ -396,6 +418,7 @@ describe('Keyboard', function() {
 
         // backspace
         ['keydown', 0, 8],
+        ['input', undefined, undefined],
         ['keyup', 0, 8],
 
         // alt up


### PR DESCRIPTION
Closes #30

This PR adds [HTML5 input event](https://developer.mozilla.org/en-US/docs/Web/Events/input) support to the library.
