### PR TITLE
test(ci): ignore lockfile when running in CRON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ matrix:
       env: TEST_TYPE=test:browser BROWSERS=Firefox MOZ_HEADLESS=1
     - node_js: 6
       env: TEST_TYPE=test:browser BROWSERS=Firefox MOZ_HEADLESS=1
-script: yarn build && yarn $TEST_TYPE
+script:
+  - '[ "$TRAVIS_EVENT_TYPE" != cron ] || yarn install --no-lockfile'
+  - yarn build && yarn $TEST_TYPE
 cache: yarn
 branches:
   except:


### PR DESCRIPTION
This will make Travis CI send notifications when an in-range dependency updates in a way that breaks the library.